### PR TITLE
Fixed points scored and conceded

### DIFF
--- a/routes/analytics.py
+++ b/routes/analytics.py
@@ -100,7 +100,7 @@ def get_player_stats(player_id=None, user_id=None):
                 try:
                     for i in range(min(len(score_for_sets), len(score_against_sets))):
                         pts_for = int(score_for_sets[i].split('-')[0])
-                        pts_against = int(score_against_sets[i].split('-')[1])
+                        pts_against = int(score_against_sets[i].split('-')[0])
                         stats['points_scored'] += pts_for
                         stats['points_conceded'] += pts_against
                 except (ValueError, IndexError):


### PR DESCRIPTION
Score_against_sets[i].split('-')[1] is accessing the wrong part of the score.
In a badminton score like "21-19", the first number represents the points scored by one player, and the second number represents the points scored by the other player. Since score_against already contains the opponent's perspective of the score (like "19-21"), we should be taking the first number from it, not the second.
