### PR TITLE
Fixed incorrect match type

### DIFF
--- a/templates/player_analytics.html
+++ b/templates/player_analytics.html
@@ -226,7 +226,7 @@ losses:{{player.losses}}:
         const matchTypeLosses = [];
 
         {% for type, stats in player.match_types.items() %}
-          matchTypeLabels.push("{{ type }}");
+          matchTypeLabels.push("{{ type|safe }}");
           matchTypeWins.push({{ stats.wins|default(0) }});
           matchTypeLosses.push({{ stats.matches|default(0) - stats.wins|default(0) }});
         {% endfor %}


### PR DESCRIPTION
The apostrophe in "Men's Singles" was being HTML-encoded and displayed literally instead of as a proper apostrophe. The fix is to add the |safe filter.