### PR TITLE
Update unitTest.py

### DIFF
--- a/tests/unitTest.py
+++ b/tests/unitTest.py
@@ -759,11 +759,14 @@ class BadmintonManagerUnitTestCase(unittest.TestCase):
             db.session.add(tournament)
             db.session.commit()
             tid = tournament.id
+            new_user_id = new_user.id
 
-        response = self.client.post(f'/tournaments/{tid}/share', data={
-            'recipient_username': 'recipient'
+        response = self.client.post('/share/create', data={
+            'tournament_id': tid,
+            'user_id': new_user_id
         }, follow_redirects=True)
-        self.assertIn(b'Tournament shared successfully', response.data)
+
+        self.assertIn(b'Tournament shared with recipient successfully!', response.data)
 
             
             


### PR DESCRIPTION
Refactor tournament sharing unit test to use '/share/create' endpoint instead of invalid '/tournaments/<id>/share' route. Adjusted form data keys to match route expectations and updated assertion to check for correct flash message content. Resolves 404 error during test execution.