### PR TITLE
Fix tournament creation test to align with actual application route

### DIFF
--- a/tests/unitTest.py
+++ b/tests/unitTest.py
@@ -744,14 +744,28 @@ class BadmintonManagerUnitTestCase(unittest.TestCase):
     # --- 3. Tournament Management ---
 
     def test_create_tournament(self):
-        """Test that a new tournament is created successfully."""
+        """Test that a new tournament is created successfully via submit_results."""
         self.login()
-        response = self.client.post('/tournaments/create', data={
-            'name': 'New Tournament',
-            'date': datetime.now().strftime('%Y-%m-%d'),
-            'location': 'Test Venue'
-        }, follow_redirects=True)
-        self.assertIn(b'Tournament created successfully', response.data)
+        data = {
+            'tournament_name': 'Test Tournament',
+            'tournament_date': '2025-05-16',
+            'location': 'Test Location',
+            'round[]': ['Round 1'],
+            'group[]': ['Group A'],
+            'team1[]': ['Player A'],
+            'team2[]': ['Player B'],
+            'score1[]': ['21-15'],
+            'score2[]': ['15-21'],
+            'match_type[]': ['Singles']
+        }
+        response = self.client.post('/submit_results', data=data, follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Tournament results submitted successfully!', response.data)
+
+        # Optionally verify tournament in DB
+        with self.app.app_context():
+            tournament = Tournament.query.filter_by(name='Test Tournament').first()
+            self.assertIsNotNone(tournament)
 
     def test_edit_tournament(self):
         """Test updating tournament details."""


### PR DESCRIPTION
Updated the test_create_tournament method to use the existing /submit_results route for creating tournaments instead of the non-existent /tournaments/create route.   The test now sends a POST request with valid tournament data including name, date, location, and match details.   Adjusted the expected response message to match the actual flash message displayed upon successful tournament creation.   Additionally, added a database check to ensure the tournament was created correctly.   This fix aligns the test with the current application flow and prevents false negatives due to incorrect routing.